### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -42,11 +42,11 @@ func newGroupResource(ctx context.Context, group models.Groupable) (*v2.Resource
 		"group_id": *groupId,
 	}
 
-	groupTraits := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupTraits := []rs.GroupTraitOption{}
 
-	resource, err := rs.NewGroupResource(*displayName, groupResourceType, *groupId, groupTraits)
+	resource, err := rs.NewGroupResource(*displayName, groupResourceType, *groupId, groupTraits,
+		rs.WithResourceProfile(profile),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -37,11 +37,11 @@ func newRoleResource(ctx context.Context, role models.DirectoryRoleable) (*v2.Re
 		"role_id": *roleId,
 	}
 
-	roleTraits := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	roleTraits := []rs.RoleTraitOption{}
 
-	resource, err := rs.NewRoleResource(*displayName, roleResourceType, *roleId, roleTraits)
+	resource, err := rs.NewRoleResource(*displayName, roleResourceType, *roleId, roleTraits,
+		rs.WithResourceProfile(profile),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -70,9 +70,7 @@ func newUserResource(ctx context.Context, user models.Userable) (*v2.Resource, e
 	}
 
 	userTraits := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
 		rs.WithUserLogin(*userName),
-		rs.WithStatus(status),
 	}
 
 	resource, err := rs.NewUserResource(
@@ -80,6 +78,8 @@ func newUserResource(ctx context.Context, user models.Userable) (*v2.Resource, e
 		userResourceType,
 		*userId,
 		userTraits,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(status), ""),
 	)
 	if err != nil {
 		return nil, err
@@ -150,12 +150,7 @@ func (o *userBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *
 
 func (o *userBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
 	var grants []*v2.Grant
-	traits, err := rs.GetUserTrait(resource)
-	if err != nil {
-		return nil, "", nil, wrapError(err, "failed to get user trait")
-	}
-
-	licensesVal, ok := traits.GetProfile().GetFields()[assignedLicense]
+	licensesVal, ok := rs.GetProfile(resource).GetFields()[assignedLicense]
 	// not all the users consumes the license.
 	if !ok {
 		return nil, "", nil, nil


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
